### PR TITLE
Implement slice/set notation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,8 @@ int main() {
 
     qasm::qasm::qubits q1(q, 8), q2(q, 8);
 
-    (q.negctrl<2>() * q.ctrl<2>() * q.h())(q1[0], q1[1], q1[2], q1[3], q1[4]);
+    (q.negctrl<2>() * q.ctrl<2>() * q.h())(q1[qasm::slice(0,4)]);
+    (q.negctrl<2>() * q.ctrl<2>() * q.h())(q1[qasm::set{0,1,2,3,4}]);
     q.u(0, 0, 1.0)(q1[0]);
     q.u(0, 0, 0.5)(q1[0]);
     (q.ctrl<2>() * q.pow(0.5) * q.u(0, 0, 1.0))(q1[0], q1[1], q1[2]);


### PR DESCRIPTION
## Summary
- add slice and set data structures for selecting multiple qubits
- extend `qubits` to support slice/set operators
- update builder to accept lists of qubit indices
- demonstrate new syntax in `main.cpp`

## Testing
- `g++ -std=c++11 main.cpp`
- `./a.out | head -n 3`

------
https://chatgpt.com/codex/tasks/task_e_688453b8e468832b889580fb259d9a59