### PR TITLE
Move builder types to qasm namespace

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -42,7 +42,7 @@ int main() {
     qasm::qasm q;
     q.register_simulator(&sim);
 
-    qasm::qasm::qubits q1(q, 8), q2(q, 8);
+    qasm::qubits q1(q, 8), q2(q, 8);
 
     (q.negctrl<2>() * q.ctrl<2>() * q.h())(q1[qasm::slice(0,4)]);
     (q.negctrl<2>() * q.ctrl<2>() * q.h())(q1[qasm::set{0,1,2,3,4}]);


### PR DESCRIPTION
## Summary
- expose `qubits`, `token`, and `builder` at the `qasm` namespace level
- adapt member function definitions accordingly
- update example code to use new type names

## Testing
- `./build.sh`
- `./a.out`

------
https://chatgpt.com/codex/tasks/task_e_688467e60ed4832ba0ffe0625c0db841