### PR TITLE
Add initializer_list indexing

### DIFF
--- a/qasm.hpp
+++ b/qasm.hpp
@@ -126,6 +126,16 @@ namespace qasm
             }
             return out;
         }
+        indices_t operator[](std::initializer_list<int> lst) const
+        {
+            indices_t out;
+            for (int v : lst)
+            {
+                assert(0 <= v && v < size_);
+                out.values.push_back(base_ + v);
+            }
+            return out;
+        }
 
     private:
         qasm &ctx_;

--- a/userqasm.cpp
+++ b/userqasm.cpp
@@ -8,7 +8,7 @@ public:
 
         qubits q1 = qalloc(8);
         qubits q2 = qalloc(8);
-        (negctrl<2>() * ctrl<2>() * h())(q1[0], q1[slice(1, 2)], q1[set{3, 4}]);
+        (negctrl<2>() * ctrl<2>() * h())(q1[0], q1[slice(1, 2)], q1[{3, 4}]);
         u(0, 0, 1.0)(q1[0]);
         u(0, 0, 0.5)(q1[0]);
         (ctrl<2>() * pow(0.5) * u(0, 0, 1.0))(q1[0], q1[1], q1[2]);


### PR DESCRIPTION
## Summary
- support braced initializer list in qubit indexing
- update example to use `q1[{3, 4}]`

## Testing
- `./build.sh`
- `./main 2>&1 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6884bb8f8050832bb4b1cf07007a6747