### PR TITLE
Add vector-based builder call

### DIFF
--- a/qasm.hpp
+++ b/qasm.hpp
@@ -191,6 +191,11 @@ namespace qasm
             std::vector<int> argv;
             argv.reserve(sizeof...(qs));
             append_args(argv, qs...);
+            (*this)(argv);
+        }
+
+        void operator()(const std::vector<int> &argv) const
+        {
             std::vector<int> pos_ctrls, neg_ctrls;
             math::matrix_t mat{};
             double pow_exp = 1.0;


### PR DESCRIPTION
## Summary
- expand `qasm::builder` with an overload taking a `std::vector<int>`
- implement the variadic operator in terms of this new overload

## Testing
- `make`
- `./main`

------
https://chatgpt.com/codex/tasks/task_e_6884c4d1fdcc832ba2736afbf3decf3c