### PR TITLE
Convert qcs simulator functions to instance methods

### DIFF
--- a/qasm.cpp
+++ b/qasm.cpp
@@ -13,7 +13,8 @@ set::set(std::initializer_list<int> lst) : indices(lst) {}
 qubits::qubits(qasm &ctx, int n) : ctx_(ctx), base_(ctx.next_id_), size_(n) {
     assert(n > 0);
     ctx.next_id_ += n;
-    qcs::alloc_qubit(n);
+    assert(ctx.simulator_ && "simulator not registered");
+    ctx.simulator_->alloc_qubit(n);
 }
 
 int qubits::operator[](int i) const {
@@ -176,8 +177,8 @@ builder qasm::negctrl(int N) {
 void qasm::dispatch(int tgt, const math::matrix_t &m, const std::vector<int> &pcs,
                     const std::vector<int> &ncs) const {
     assert(simulator_ && "simulator not registered");
-    qcs::gate_matrix(simulator_, m, tgt, pcs.data(), static_cast<int>(pcs.size()),
-                     ncs.data(), static_cast<int>(ncs.size()));
+    simulator_->gate_matrix(m, tgt, pcs.data(), static_cast<int>(pcs.size()),
+                            ncs.data(), static_cast<int>(ncs.size()));
 }
 
 qubits qasm::qalloc(int n) {

--- a/qcs.cpp
+++ b/qcs.cpp
@@ -1,12 +1,12 @@
 #include "qcs.hpp"
 #include <cstdio>
 
-void qcs::alloc_qubit(int n)
+void qcs::simulator::alloc_qubit(int n)
 {
     fprintf(stderr, "[qubit declare] %d\n", n);
 }
 
-void qcs::gate_matrix(simulator *, math::matrix_t matrix, int tgt, int const *pc_list, int num_pcs, int const *nc_list, int num_ncs)
+void qcs::simulator::gate_matrix(math::matrix_t matrix, int tgt, int const *pc_list, int num_pcs, int const *nc_list, int num_ncs)
 {
     fprintf(stderr, "gate matrix={");
 #pragma unroll

--- a/qcs.hpp
+++ b/qcs.hpp
@@ -3,7 +3,9 @@
 #include "math.hpp"
 
 namespace qcs {
-    struct simulator {};
-    void alloc_qubit(int n);
-    void gate_matrix(simulator*, math::matrix_t matrix, int tgt, int const* pc_list, int num_pcs, int const* nc_list, int num_ncs);
+    struct simulator {
+        void alloc_qubit(int n);
+        void gate_matrix(math::matrix_t matrix, int tgt, int const* pc_list,
+                          int num_pcs, int const* nc_list, int num_ncs);
+    };
 }


### PR DESCRIPTION
## Summary
- make `alloc_qubit` and `gate_matrix` instance methods of `qcs::simulator`
- update calls in `qasm` implementation

## Testing
- `make all`
- `./main`

------
https://chatgpt.com/codex/tasks/task_e_6884cdc4c838832b8544d9ae5165395c